### PR TITLE
Fix invalid JSON handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,9 @@ def favicon():
 
 @app.route('/summarize', methods=['POST'])
 def summarize():
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON payload."}), 400
     url = data.get("url")
     if not url:
         return jsonify({"error": "No URL provided."}), 400
@@ -99,7 +101,9 @@ def summarize():
 
 @app.route('/summarize-transcript', methods=['POST'])
 def summarize_transcript():
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON payload."}), 400
     transcript = data.get("transcript")
     if not transcript:
         return jsonify({"error": "No transcript provided."}), 400


### PR DESCRIPTION
## Summary
- validate request bodies in both API POST endpoints to avoid server errors on invalid JSON

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3b0c7c208326b60da98d6389d617