### PR TITLE
Fix container start failure with default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ COPY . .
 
 EXPOSE 7860
 
+ENV PORT 7860
 CMD gunicorn app:app --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- set default `PORT` environment variable to avoid container startup errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4cbd92988326b99ab5f4088155df